### PR TITLE
Bug fix and minor refactor of to be used utility function

### DIFF
--- a/src/com/jcope/vnc/server/ClientHandler.java
+++ b/src/com/jcope/vnc/server/ClientHandler.java
@@ -1,5 +1,6 @@
 package com.jcope.vnc.server;
 
+import static com.jcope.debug.Debug.DEBUG;
 import static com.jcope.debug.Debug.assert_;
 import static com.jcope.vnc.shared.ScreenSelector.getScreenDevicesOrdered;
 
@@ -1015,7 +1016,11 @@ public class ClientHandler extends Thread
 			Monitor monitor;
 			synchronized(monitorRef)
 			{
-				monitor = (Monitor) monitorRef[0].get();
+				monitor = (monitorRef[0] == null) ? null : (Monitor) monitorRef[0].get();
+			}
+			if (monitor == null) {
+				if (DEBUG) {LLog.w("Instance not bound to a monitor");}
+				return;
 			}
 			paused = newPaused;
 			monitor.setPaused(newPaused);


### PR DESCRIPTION
1. fixed null pointer exception that occurs on invalid login attempt
2. refactored TaskDispatcher::cancel() implementation to be more readable/transactionally friendly with multiple keys

*Note*: The cancel operation now locks BOTH in-queue and the real-queue and so basically operates now like a global interpreter lock, but only performs queue management while in this state. There is no chance of a deadlock because this doubly locked state on one thread is NOT POSSIBLE in any other context.